### PR TITLE
Purchase trees optional country code

### DIFF
--- a/API/Impact-API.v1.yaml
+++ b/API/Impact-API.v1.yaml
@@ -108,7 +108,7 @@ paths:
                     treeUrl:
                       type: string
                       example: "https://ecologi.com/test?tree=604a74856345f7001caff578"
-                      description: The URL for the trees you just planted
+                      description: The URL for the first tree you just planted
                     name:
                       type: string
                       example: Elijah Wood
@@ -120,6 +120,13 @@ paths:
                         - UK
                         - US
                       description: The countryCode you passed in the request body
+                    treeUrls:
+                      type: array
+                      example:
+                        - "https://ecologi.com/test?tree=604a74856345f7001caff578"
+                        - "https://ecologi.com/test?tree=604a74856345f7001caff579"
+                        - "https://ecologi.com/test?tree=604a74856345f7001caff580"
+                      description: URLs of all trees you just planted
                   required:
                     - amount
                     - currency
@@ -132,7 +139,9 @@ paths:
                     treeUrl: "https://ecologi.com/test?tree=604a74856345f7001caff578"
                     name: Alex's trees
                     countryCode: US
-          description: "If your request is successful you’ll receive an array of JSON objects containing information about your purchase. Including the amount it cost, the currency billed, the name (if passed in the request), the country code and the URL of the tree planted in your Ecologi profile forest."
+                    treeUrls:
+                      - "https://ecologi.com/test?tree=604a74856345f7001caff578"
+          description: "If your request is successful you’ll receive a JSON object containing information about your purchase. Including the amount it cost, the currency billed, the name (if passed in the request), the country code, the URL of the first tree planted in your Ecologi profile forest and URLs of all planted trees (if applicable)."
       parameters:
         - schema:
             type: string

--- a/API/Impact-API.v1.yaml
+++ b/API/Impact-API.v1.yaml
@@ -35,8 +35,6 @@ paths:
 
           If "countryCode" key is present and valid, local trees will be purchased for the specified country. At the moment valid country codes are 'AU', 'UK' and 'US'.
 
-          If "userId" (unique customer identifier) key is present and valid, purchased trees will be attributed to it regardless of the above mentioned 24hrs time window.
-
           Passing "test: true" will return the anticipated response, but you will not be charged for these trees, nor will they show in your Ecologi profile forest.
         content:
           application/json:
@@ -60,11 +58,6 @@ paths:
                   maxLength: 2
                   example: UK
                   description: The country for local trees purchase
-                userId:
-                  type: string
-                  minLength: 1
-                  example: abc1234567890
-                  description: Unique customer identifier
                 test:
                   type: boolean
                   description: Whether this is a test transaction or not
@@ -88,21 +81,6 @@ paths:
                   number: 2
                   name: My UK trees
                   countryCode: UK
-              Buy trees with userId:
-                value:
-                  number: 2
-                  userId: abc01234567890
-              Buy trees with userId and name:
-                value:
-                  number: 2
-                  name: Alex's trees
-                  userId: abc01234567890
-              Buy trees with userId and name (test):
-                value:
-                  number: 2
-                  name: Alex's trees
-                  userId: abc01234567890
-                  test: true
       responses:
         "201":
           content:
@@ -137,10 +115,6 @@ paths:
                     type: string
                     example: ZZ
                     description: The countryCode you passed in the request body or ZZ (Unknown or unspecified country)
-                  userId:
-                    type: string
-                    example: abc1234567890
-                    description: Unique customer identifier
                 required:
                   - amount
                   - currency
@@ -153,7 +127,6 @@ paths:
                     treeUrl: "https://ecologi.com/test?tree=604a74856345f7001caff578"
                     name: Alex's trees
                     countryCode: ZZ
-                    userId: abc1234567890
           description: "If your request is successful you’ll receive a JSON object containing information about your purchase. Including the amount it cost, the currency billed, the name, the country code and the userId (if passed in the request) and the URL of the tree planted in your Ecologi profile forest."
       parameters:
         - schema:

--- a/API/Impact-API.v1.yaml
+++ b/API/Impact-API.v1.yaml
@@ -33,6 +33,8 @@ paths:
 
           If multiple requests are made to plant trees with the same name within 24hrs, they will accumulate on a single tile. If you would like to avoid this you can provide a different name value like maybe adding the first letter of the surname to the next lot or space the requests greater than 24hrs apart.
 
+          If "countryCode" key is present and valid, local trees will be purchased for the specified country. At the moment valid country codes are 'AU', 'UK' and 'US'.
+
           If "userId" (unique customer identifier) key is present and valid, purchased trees will be attributed to it regardless of the above mentioned 24hrs time window.
 
           Passing "test: true" will return the anticipated response, but you will not be charged for these trees, nor will they show in your Ecologi profile forest.
@@ -52,6 +54,12 @@ paths:
                   minLength: 1
                   example: Elijah Wood
                   description: The "funded by" name for these trees
+                countryCode:
+                  type: string
+                  minLength: 2
+                  maxLength: 2
+                  example: UK
+                  description: The country for local trees purchase
                 userId:
                   type: string
                   minLength: 1
@@ -75,6 +83,11 @@ paths:
                   number: 2
                   name: Alex's trees
                   test: true
+              Buy local trees with name:
+                value:
+                  number: 2
+                  name: My UK trees
+                  countryCode: UK
               Buy trees with userId:
                 value:
                   number: 2
@@ -120,6 +133,10 @@ paths:
                     type: string
                     example: Elijah Wood
                     description: The name you passed in the request body
+                  countryCode:
+                    type: string
+                    example: ZZ
+                    description: The countryCode you passed in the request body or ZZ (Unknown or unspecified country)
                   userId:
                     type: string
                     example: abc1234567890
@@ -135,8 +152,9 @@ paths:
                     currency: GBP
                     treeUrl: "https://ecologi.com/test?tree=604a74856345f7001caff578"
                     name: Alex's trees
+                    countryCode: ZZ
                     userId: abc1234567890
-          description: "If your request is successful you’ll receive a JSON object containing information about your purchase. Including the amount it cost, the currency billed, the name and the userId (if passed in the request) and the URL of the tree planted in your Ecologi profile forest."
+          description: "If your request is successful you’ll receive a JSON object containing information about your purchase. Including the amount it cost, the currency billed, the name, the country code and the userId (if passed in the request) and the URL of the tree planted in your Ecologi profile forest."
       parameters:
         - schema:
             type: string

--- a/API/Impact-API.v1.yaml
+++ b/API/Impact-API.v1.yaml
@@ -24,7 +24,7 @@ paths:
       operationId: create-impact-trees
       description: Use this endpoint to purchase 1 or more trees per request
       security:
-        - API Key: []
+        - API Key: [ ]
       requestBody:
         description: |-
           Send a JSON body object with key "number" and a value equalling the number of trees to plant in your forest for this request. You can optionally add a "name" key, which will be shown when you view the trees in your Ecologi forest.
@@ -87,38 +87,43 @@ paths:
             application/json:
               schema:
                 description: ""
-                type: object
-                properties:
-                  amount:
-                    type: number
-                    example: 0.38
-                    description: The total cost of this transaction
-                  currency:
-                    type: string
-                    enum:
-                      - GBP
-                      - USD
-                      - EUR
-                      - CAD
-                      - AUD
-                    example: GBP
-                    description: The currency of the amount
-                  treeUrl:
-                    type: string
-                    example: "https://ecologi.com/test?tree=604a74856345f7001caff578"
-                    description: The URL for the trees you just planted
-                  name:
-                    type: string
-                    example: Elijah Wood
-                    description: The name you passed in the request body
-                  countryCode:
-                    type: string
-                    example: ZZ
-                    description: The countryCode you passed in the request body or ZZ (Unknown or unspecified country)
-                required:
-                  - amount
-                  - currency
-                  - treeUrl
+                type: array
+                items:
+                  type: object
+                  properties:
+                    amount:
+                      type: number
+                      example: 0.38
+                      description: The total cost of this transaction
+                    currency:
+                      type: string
+                      enum:
+                        - GBP
+                        - USD
+                        - EUR
+                        - CAD
+                        - AUD
+                      example: GBP
+                      description: The currency of the amount
+                    treeUrl:
+                      type: string
+                      example: "https://ecologi.com/test?tree=604a74856345f7001caff578"
+                      description: The URL for the trees you just planted
+                    name:
+                      type: string
+                      example: Elijah Wood
+                      description: The name you passed in the request body
+                    countryCode:
+                      type: string
+                      enum:
+                        - AU
+                        - UK
+                        - US
+                      description: The countryCode you passed in the request body
+                  required:
+                    - amount
+                    - currency
+                    - treeUrl
               examples:
                 3 trees purchased:
                   value:
@@ -126,15 +131,15 @@ paths:
                     currency: GBP
                     treeUrl: "https://ecologi.com/test?tree=604a74856345f7001caff578"
                     name: Alex's trees
-                    countryCode: ZZ
-          description: "If your request is successful you’ll receive a JSON object containing information about your purchase. Including the amount it cost, the currency billed, the name (if passed in the request), the country code and the URL of the tree planted in your Ecologi profile forest."
+                    countryCode: US
+          description: "If your request is successful you’ll receive an array of JSON objects containing information about your purchase. Including the amount it cost, the currency billed, the name (if passed in the request), the country code and the URL of the tree planted in your Ecologi profile forest."
       parameters:
         - schema:
             type: string
           in: header
           name: "Idempotency-Key: 1234567890"
           description: This random request key allows you to safely retry requests without accidentally performing the same operation twice.
-    parameters: []
+    parameters: [ ]
   /impact/carbon:
     post:
       summary: Purchase carbon offsets
@@ -190,7 +195,7 @@ paths:
                     currency: GBP
       description: Use this endpoint to purchase 1 or more KG of carbon offsets per request
       security:
-        - API Key: []
+        - API Key: [ ]
       parameters:
         - schema:
             type: string

--- a/API/Impact-API.v1.yaml
+++ b/API/Impact-API.v1.yaml
@@ -127,7 +127,7 @@ paths:
                     treeUrl: "https://ecologi.com/test?tree=604a74856345f7001caff578"
                     name: Alex's trees
                     countryCode: ZZ
-          description: "If your request is successful you’ll receive a JSON object containing information about your purchase. Including the amount it cost, the currency billed, the name, the country code and the URL of the tree planted in your Ecologi profile forest."
+          description: "If your request is successful you’ll receive a JSON object containing information about your purchase. Including the amount it cost, the currency billed, the name (if passed in the request), the country code and the URL of the tree planted in your Ecologi profile forest."
       parameters:
         - schema:
             type: string

--- a/API/Impact-API.v1.yaml
+++ b/API/Impact-API.v1.yaml
@@ -127,7 +127,7 @@ paths:
                     treeUrl: "https://ecologi.com/test?tree=604a74856345f7001caff578"
                     name: Alex's trees
                     countryCode: ZZ
-          description: "If your request is successful you’ll receive a JSON object containing information about your purchase. Including the amount it cost, the currency billed, the name, the country code and the userId (if passed in the request) and the URL of the tree planted in your Ecologi profile forest."
+          description: "If your request is successful you’ll receive a JSON object containing information about your purchase. Including the amount it cost, the currency billed, the name, the country code and the URL of the tree planted in your Ecologi profile forest."
       parameters:
         - schema:
             type: string

--- a/API/Impact-API.v1.yaml
+++ b/API/Impact-API.v1.yaml
@@ -33,6 +33,8 @@ paths:
 
           If multiple requests are made to plant trees with the same name within 24hrs, they will accumulate on a single tile. If you would like to avoid this you can provide a different name value like maybe adding the first letter of the surname to the next lot or space the requests greater than 24hrs apart.
 
+          If "userId" (unique customer identifier) key is present and valid, purchased trees will be attributed to it regardless of the above mentioned 24hrs time window.
+
           Passing "test: true" will return the anticipated response, but you will not be charged for these trees, nor will they show in your Ecologi profile forest.
         content:
           application/json:
@@ -50,6 +52,11 @@ paths:
                   minLength: 1
                   example: Elijah Wood
                   description: The "funded by" name for these trees
+                userId:
+                  type: string
+                  minLength: 1
+                  example: abc1234567890
+                  description: Unique customer identifier
                 test:
                   type: boolean
                   description: Whether this is a test transaction or not
@@ -67,6 +74,21 @@ paths:
                 value:
                   number: 2
                   name: Alex's trees
+                  test: true
+              Buy trees with userId:
+                value:
+                  number: 2
+                  userId: abc01234567890
+              Buy trees with userId and name:
+                value:
+                  number: 2
+                  name: Alex's trees
+                  userId: abc01234567890
+              Buy trees with userId and name (test):
+                value:
+                  number: 2
+                  name: Alex's trees
+                  userId: abc01234567890
                   test: true
       responses:
         "201":
@@ -98,6 +120,10 @@ paths:
                     type: string
                     example: Elijah Wood
                     description: The name you passed in the request body
+                  userId:
+                    type: string
+                    example: abc1234567890
+                    description: Unique customer identifier
                 required:
                   - amount
                   - currency
@@ -109,7 +135,8 @@ paths:
                     currency: GBP
                     treeUrl: "https://ecologi.com/test?tree=604a74856345f7001caff578"
                     name: Alex's trees
-          description: "If your request is successful you’ll receive a JSON object containing information about your purchase. Including the amount it cost, the currency billed, the name (if passed in the request) and the URL of the tree planted in your Ecologi profile forest."
+                    userId: abc1234567890
+          description: "If your request is successful you’ll receive a JSON object containing information about your purchase. Including the amount it cost, the currency billed, the name and the userId (if passed in the request) and the URL of the tree planted in your Ecologi profile forest."
       parameters:
         - schema:
             type: string


### PR DESCRIPTION
Added info about optional countryCodoe param in purchase trees endpoint

[Shortcut URL](https://app.shortcut.com/ecologi/story/17481/add-local-trees-uk-us-aus-to-api)

[old PR (closed) in platform repo
](https://github.com/ecologi/platform/pull/1493)
[Related changes in platform repo
](https://github.com/ecologi/platform/pull/1817)