### PR TITLE
fix (api-docs): updates idempotency key to not include example numbers

### DIFF
--- a/API/Impact-API.v1.yaml
+++ b/API/Impact-API.v1.yaml
@@ -131,7 +131,7 @@ paths:
         - schema:
             type: string
           in: header
-          name: "Idempotency-Key: 1234567890"
+          name: "Idempotency-Key"
           description: This random request key allows you to safely retry requests without accidentally performing the same operation twice.
     parameters: []
   /impact/carbon:
@@ -215,7 +215,7 @@ paths:
         - schema:
             type: string
           in: header
-          name: "Idempotency-Key: 1234567890"
+          name: "Idempotency-Key"
           description: This random request key allows you to safely retry requests without accidentally performing the same operation twice.
       requestBody:
         content:


### PR DESCRIPTION
Currently, the Stoplight API docs are sending the idempotency key as `idempotency-key: 1234567890` which I believe is causing an error, not allowing users to send a request to the mock server.

Actions: Updated references of the idempotency key to remove the `: 1234567890` string part

<img width="172" alt="image" src="https://user-images.githubusercontent.com/49349009/226299912-312a837b-6de6-4ee9-a274-ade6918eadf0.png">

Shortcut ticket: https://app.shortcut.com/ecologi/story/30591/api-issues
