### PR TITLE
chore: add documentation for landing page deployment

### DIFF
--- a/LandingPage.md
+++ b/LandingPage.md
@@ -1,0 +1,82 @@
+# Welcome to your Ecologi workspace
+
+Ecologi is a platform to reverse and halt climate change. We facilitate the funding of climate projects and tree planting projects around the world, allowing ordinary people to contribute to real climate action. Our mission is to remove 50% of global CO2 emissions by 2040 and to responsibly plant billions of trees every year. To find out more about Ecologi and our organisational mission, take a look at our [main site](https://ecologi.com/).
+
+By bringing a community together to help restore our planet, we strive to create real positive change. We offer a range of product options, catering for individuals, families and businesses.
+
+## Our Climate Action ✊
+
+### 📉 Carbon reduction projects
+
+You will fund the world's best climate crisis solutions. Our climate projects include renewable energy generation, rainforest protection, and community initiatives such as providing access to clean water.
+
+Each and every tonne of carbon that we offset through these climate projects is certified by an industry-leading formal standard, such as Gold Standard or Verified Carbon Standard and we monitor our impact across all the projects we have funded.
+
+[Find out more about our climate projects](https://ecologi.com/projects).
+
+### 🌱 Tree-planting
+
+Our main tree planting sites are in Madagascar, Mozambique and Nicaragua. We plant a native and biodiverse mix of tree species and our planting projects help to support local communities and reduce poverty by employing local workers.
+We also offer local reforestation projects in the UK, Australia, and the US, where you can fund trees in your own country.
+
+These baby trees grow to support communities and wildlife, improve soil and water quality, and boost the biodiversity of the local area.
+
+[Find out more information on our tree planting sites](https://ecologi.com/articles/updates/year-2-of-the-ecologi-forests)
+
+With every account you will also get your very own impact profile. This allows you to track your climate action, grow your own virtual forest, and set yourself low-carbon lifestyle goals.
+
+## Our core products
+
+### 🌍 Personal & Family Subscriptions
+
+Our subscription services allow you to become _Climate Positive_, meaning you fund climate solutions each month to offset the impact of your own carbon footprint, plus a bit extra. Alongside this you also plant trees and start growing your own forest. We offer plans which start at as little as £1.25 a week and provide a simple way to supercharge your impact above just limiting your own damage.
+
+[Learn more about our subscriptions](https://ecologi.com/plan)
+
+_Note: Personal and family plans do not have access to the API services listed below. Please start a Climate Positive Workforce or sign up for an Impact Only account if you wish use our integrations._
+
+### 🌳 Climate Positive Workforce
+
+We offer businesses the opportunity to become a Climate Positive Workforce (CPW). All employees' carbon footprints are more than offset through this subscription. This includes emissions from both their professional and personal lives, including travel, holidays, food, hobbies and everything else! All CPW subscriptions include unlimited access to our API services listed below.
+
+[Learn more about our Climate Positive Workforce plans](https://ecologi.com/business)
+
+### 🍃 Impact only accounts
+
+In an effort to make collective climate action accessible to all businesses, we offer what we call an "Impact Only" Ecologi account. Rather than a subscription you can add climate impact whenever suits you. You'll have full access to the API and integrations listed below if you wish to automate your climate impact, or you can buy it at any time from your Ecologi profile.
+
+[Get started today with an Impact-Only account](https://ecologi.com/pay-as-you-go)
+
+### 🎁 Gifting
+
+Our zero-waste tree planting gifts allow you to give your love one the gift of long lasting climate action. Choose from planting 100, 250 or 500 trees.
+
+[Find out more about our gifts](https://ecologi.com/gifting)
+
+## Ecologi APIs
+
+Our APIs provide a simple and easy-to-use way for you to automate the purchase of trees or carbon offsets directly from your application or service. You can also use our APIs to directly access your impact statistics and gain real-time insights and data on your total impact, total tonnes of CO2e removed, and total number of trees planted.
+
+| Purchasing Impact API | Reporting API                     |
+| --------------------- | --------------------------------- |
+| Buy trees             | Get all impact                    |
+| Buy carbon offsets    | Get total tonnes of Co2e removed  |
+|                       | Get total number of trees planted |
+
+<!-- theme: success -->
+
+> ### Read the docs
+>
+> ⬅️ Select the **Public API Docs** menu item on the left to get started.
+
+### ⚡️ Shopify and Zapier integrations
+
+We have plugins for both Shopify and Zapier, allowing you to fund reforestation projects automatically for every sale you make.
+
+[Read more about our integrations](https://ecologi.com/articles/product/automatic-tree-planting-via-shopify)
+
+## We’re here to help
+
+If you have any questions, please get in touch and let us know how we can help at [support@ecologi.com](mailto:support@ecologi.com).
+
+🌳 Happy API-ing 🌳

--- a/README.md
+++ b/README.md
@@ -1,82 +1,13 @@
-# Welcome to your Ecologi workspace
+# Ecologi Public API Docs
 
-Ecologi is a platform to reverse and halt climate change. We facilitate the funding of climate projects and tree planting projects around the world, allowing ordinary people to contribute to real climate action. Our mission is to remove 50% of global CO2 emissions by 2040 and to responsibly plant billions of trees every year. To find out more about Ecologi and our organisational mission, take a look at our [main site](https://ecologi.com/).
+This repo contains the docs for https://docs.ecologi.com/
 
-By bringing a community together to help restore our planet, we strive to create real positive change. We offer a range of product options, catering for individuals, families and businesses.
+These documents are deployed and displayed using [Stoplight](https://stoplight.io/)
 
-## Our Climate Action ✊
+## API Documents
 
-### 📉 Carbon reduction projects
+Files in the [API](./API) folder automatically update the pages under https://docs.ecologi.com/docs/public-api-docs/ when pushed to master
 
-You will fund the world's best climate crisis solutions. Our climate projects include renewable energy generation, rainforest protection, and community initiatives such as providing access to clean water.
+## Landing Page
 
-Each and every tonne of carbon that we offset through these climate projects is certified by an industry-leading formal standard, such as Gold Standard or Verified Carbon Standard and we monitor our impact across all the projects we have funded.
-
-[Find out more about our climate projects](https://ecologi.com/projects).
-
-### 🌱 Tree-planting
-
-Our main tree planting sites are in Madagascar, Mozambique and Nicaragua. We plant a native and biodiverse mix of tree species and our planting projects help to support local communities and reduce poverty by employing local workers.
-We also offer local reforestation projects in the UK, Australia, and the US, where you can fund trees in your own country.
-
-These baby trees grow to support communities and wildlife, improve soil and water quality, and boost the biodiversity of the local area.
-
-[Find out more information on our tree planting sites](https://ecologi.com/articles/updates/year-2-of-the-ecologi-forests)
-
-With every account you will also get your very own impact profile. This allows you to track your climate action, grow your own virtual forest, and set yourself low-carbon lifestyle goals.
-
-## Our core products
-
-### 🌍 Personal & Family Subscriptions
-
-Our subscription services allow you to become _Climate Positive_, meaning you fund climate solutions each month to offset the impact of your own carbon footprint, plus a bit extra. Alongside this you also plant trees and start growing your own forest. We offer plans which start at as little as £1.25 a week and provide a simple way to supercharge your impact above just limiting your own damage.
-
-[Learn more about our subscriptions](https://ecologi.com/plan)
-
-_Note: Personal and family plans do not have access to the API services listed below. Please start a Climate Positive Workforce or sign up for an Impact Only account if you wish use our integrations._
-
-### 🌳 Climate Positive Workforce
-
-We offer businesses the opportunity to become a Climate Positive Workforce (CPW). All employees' carbon footprints are more than offset through this subscription. This includes emissions from both their professional and personal lives, including travel, holidays, food, hobbies and everything else! All CPW subscriptions include unlimited access to our API services listed below.
-
-[Learn more about our Climate Positive Workforce plans](https://ecologi.com/business)
-
-### 🍃 Impact only accounts
-
-In an effort to make collective climate action accessible to all businesses, we offer what we call an "Impact Only" Ecologi account. Rather than a subscription you can add climate impact whenever suits you. You'll have full access to the API and integrations listed below if you wish to automate your climate impact, or you can buy it at any time from your Ecologi profile.
-
-[Get started today with an Impact-Only account](https://ecologi.com/pay-as-you-go)
-
-### 🎁 Gifting
-
-Our zero-waste tree planting gifts allow you to give your love one the gift of long lasting climate action. Choose from planting 100, 250 or 500 trees.
-
-[Find out more about our gifts](https://ecologi.com/gifting)
-
-## Ecologi APIs
-
-Our APIs provide a simple and easy-to-use way for you to automate the purchase of trees or carbon offsets directly from your application or service. You can also use our APIs to directly access your impact statistics and gain real-time insights and data on your total impact, total tonnes of CO2e removed, and total number of trees planted.
-
-| Purchasing Impact API | Reporting API                     |
-| --------------------- | --------------------------------- |
-| Buy trees             | Get all impact                    |
-| Buy carbon offsets    | Get total tonnes of Co2e removed  |
-|                       | Get total number of trees planted |
-
-<!-- theme: success -->
-
-> ### Read the docs
->
-> ⬅️ Select the **Public API Docs** menu item on the left to get started.
-
-### ⚡️ Shopify and Zapier integrations
-
-We have plugins for both Shopify and Zapier, allowing you to fund reforestation projects automatically for every sale you make.
-
-[Read more about our integrations](https://ecologi.com/articles/product/automatic-tree-planting-via-shopify)
-
-## We’re here to help
-
-If you have any questions, please get in touch and let us know how we can help at [support@ecologi.com](mailto:support@ecologi.com).
-
-🌳 Happy API-ing 🌳
+The "landing page", i.e. the content you see directly on https://docs.ecologi.com does not automatically update. We keep it up-to-date here in the file [`LandingPage.md`](./LandingPage.md), but when changed this must be manually copied into our [Stoplight account settings](https://docs.ecologi.com/admin/settings) under the heading "Landing Page".


### PR DESCRIPTION
It seems we'd been under the incorrect assumption that the README.md file in this project was connected automatically to the landing page on docs.ecologi.com. That is not the case, instead that page is controlled within stoplight settings. This PR makes the setup clear.