### PR TITLE
Remove reference to appending purchases to subscription invoices as this is no longer the case

### DIFF
--- a/API/Impact-API.v1.yaml
+++ b/API/Impact-API.v1.yaml
@@ -3,7 +3,7 @@ info:
   title: Purchasing Impact API
   version: "1.0"
   description: |
-    Purchase trees or carbon avoidance credits directly from your application or service with our JSON impact API. You simply tell our API how many trees or credits you would like to buy. Then, on the 1st of every month, any impact purchased via the API will be added to your next subscription invoice or billed straight away if you don't have an Ecologi Climate Action Workforce subscription.
+    Purchase trees or carbon avoidance credits directly from your application or service with our JSON impact API. You simply tell our API how many trees or credits you would like to buy. Any impact purchased via the API will be billed on the 1st of every month.
 
     If you’d like to create a subscription-free account, head to: https://ecologi.com/pay-as-you-go. With an account you can find your API key on the 'Impact API' page.
 


### PR DESCRIPTION
Remove reference to appending purchases to subscription invoices if the user has one as this is no longer the case after https://github.com/ecologi/platform/pull/2688