### PR TITLE
chore: match GBP amount used in response example

### DIFF
--- a/API/Impact-API.v1.yaml
+++ b/API/Impact-API.v1.yaml
@@ -158,7 +158,7 @@ paths:
                     description: The number of units you purchased converted to tonnes
                   amount:
                     type: number
-                    example: 7.4
+                    example: 0.09
                     description: The total cost of this transaction
                   currency:
                     type: string


### PR DESCRIPTION
I missed one change from https://github.com/ecologi/public-api-docs/pull/15